### PR TITLE
refactor: 이메일 인증 방식을 인증 코드에서 인증 링크로 변경

### DIFF
--- a/src/main/java/com/backend_potato/edubox_team2/domain/deprecated/entity/EmailVerificationRequestDTO.java
+++ b/src/main/java/com/backend_potato/edubox_team2/domain/deprecated/entity/EmailVerificationRequestDTO.java
@@ -1,4 +1,4 @@
-package com.backend_potato.edubox_team2.domain.users.entity;
+package com.backend_potato.edubox_team2.domain.deprecated.entity;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -11,11 +11,8 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class VerifyCodeRequestDTO {
+public class EmailVerificationRequestDTO {
     @NotBlank(message = "이메일은 필수 항목입니다.")
     @Email(message = "유효한 이메일 주소를 입력해야 합니다.")
     private String email;
-
-    @NotBlank(message = "인증 코드는 필수 항목입니다.")
-    private String code;
 }

--- a/src/main/java/com/backend_potato/edubox_team2/domain/deprecated/entity/VerifyCodeRequestDTO.java
+++ b/src/main/java/com/backend_potato/edubox_team2/domain/deprecated/entity/VerifyCodeRequestDTO.java
@@ -1,4 +1,4 @@
-package com.backend_potato.edubox_team2.domain.users.entity;
+package com.backend_potato.edubox_team2.domain.deprecated.entity;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -11,8 +11,11 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class EmailVerificationRequestDTO {
+public class VerifyCodeRequestDTO {
     @NotBlank(message = "이메일은 필수 항목입니다.")
     @Email(message = "유효한 이메일 주소를 입력해야 합니다.")
     private String email;
+
+    @NotBlank(message = "인증 코드는 필수 항목입니다.")
+    private String code;
 }

--- a/src/main/java/com/backend_potato/edubox_team2/domain/users/controller/UserController.java
+++ b/src/main/java/com/backend_potato/edubox_team2/domain/users/controller/UserController.java
@@ -2,6 +2,8 @@ package com.backend_potato.edubox_team2.domain.users.controller;
 
 import com.backend_potato.edubox_team2.domain.users.entity.*;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -11,10 +13,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "User API", description = "회원 API입니다.")
@@ -25,20 +24,19 @@ public interface UserController {
     @PostMapping("/signup")
     ResponseEntity<Void> createUser(@RequestBody SignupRequestDTO signupRequestDTO);
 
+    @Operation(summary = "이메일 인증 링크 검증", description = "이메일로 전송된 인증 링크를 클릭하면 해당 토큰을 검증합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "이메일 인증에 성공했습니다."),
+            @ApiResponse(responseCode = "400", description = "유효하지 않거나 만료된 토큰입니다.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 에러 발생", content = @Content)
+    })
+    @GetMapping("/verify-link")
+    ResponseEntity<String> verifyLink(@RequestParam("token") String token);
+
     @Operation(summary="로그인", description= "사용자가 로그인 시 사용되는 api입니다.")
     @ApiResponse(responseCode = "201", description = "로그인에 성공하였습니다.")
     @PostMapping("/login")
     ResponseEntity<String> getUserByEmailAndPw(@RequestBody @Valid LoginRequestDTO loginRequestDTO, HttpServletResponse response);
-
-//    @Operation(summary="프로필 업데이트", description= "프로필 업데이트 시 사용되는 api입니다.")
-//    @ApiResponses(value = {
-//            @ApiResponse(responseCode = "200", description = "프로필 업데이트에 성공하였습니다."),
-//            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content(mediaType = "application/json")),
-//            @ApiResponse(responseCode = "404", description = "해당 이메일을 가진 회원이 없습니다.", content = @Content(mediaType = "application/json"))
-//    })
-//    @PatchMapping(value = "/update-profile", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_OCTET_STREAM_VALUE})
-//    ResponseEntity<Void> updateProfile(@RequestPart(value = "request") ProfileUpdateRequestDTO profileUpdateRequestDTO, @RequestPart(value = "image", required = false) MultipartFile image,
-//                                       HttpServletRequest request);
 
     @Operation(summary = "로그아웃", description = "현재 로그인된 사용자를 로그아웃합니다.")
     @ApiResponses(value = {
@@ -49,23 +47,6 @@ public interface UserController {
     @PostMapping("/logout")
     ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response);
 
-    @Operation(summary = "이메일 인증 코드 전송", description = "사용자 이메일로 인증 코드를 전송합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "이메일 인증 코드 전송에 성공했습니다."),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.", content = @Content),
-            @ApiResponse(responseCode = "500", description = "서버 에러 발생", content = @Content)
-    })
-    @PostMapping("/send-verification")
-    ResponseEntity<String> sendVerificationEmail(@RequestBody EmailVerificationRequestDTO requestDTO);
-
-    @Operation(summary = "이메일 인증 코드 검증", description = "사용자가 입력한 인증 코드를 검증합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "이메일 인증 코드 검증에 성공했습니다."),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.", content = @Content),
-            @ApiResponse(responseCode = "500", description = "서버 에러 발생", content = @Content)
-    })
-    @PostMapping("/verify-code")
-    ResponseEntity<String> verifyEmailCode(@RequestBody VerifyCodeRequestDTO requestDTO);
 
     @Operation(summary = "프로필 업데이트", description = "프로필 업데이트 시 사용되는 API입니다.")
     @ApiResponses(value = {
@@ -78,4 +59,49 @@ public interface UserController {
             @RequestPart(value = "request") ProfileUpdateRequestDTO profileUpdateRequestDTO,
             @RequestPart(value = "image", required = false) MultipartFile image,
             HttpServletRequest request);
+
+    @Operation(summary = "사용자 복구", description = "Soft-Delete 상태의 사용자를 복구합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자 복구 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 이메일을 가진 사용자가 존재하지 않음", content = @Content),
+            @ApiResponse(responseCode = "409", description = "사용자가 이미 활성화 상태임", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 에러 발생", content = @Content)
+    })
+    @PatchMapping("/restore/{email}")
+    ResponseEntity<Void> restoreUser(@PathVariable("email") String email);
+
+    @Operation(summary = "사용자 Soft-Delete", description = "현재 로그인된 사용자를 Soft-Delete 처리하고 자동으로 로그아웃합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Soft-Delete 성공 및 사용자 로그아웃 완료"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content),
+            @ApiResponse(responseCode = "409", description = "사용자가 이미 Soft-Delete 상태임", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 에러 발생", content = @Content)
+    })
+    @DeleteMapping("/soft-delete")
+    ResponseEntity<Void> softDeleteUser(HttpServletRequest request);
+
+    @Operation(summary = "이메일 중복 확인", description = "입력한 이메일이 이미 등록되어 있는지 확인합니다.")
+    @ApiResponse(responseCode = "200", description = "이메일 중복 확인에 성공하였습니다.")
+    @Parameters(value = {
+            @Parameter(name="email", description = "사용자 이메일", example = "spancer1@naver.com")
+    })
+    @GetMapping("/check-email")
+    ResponseEntity<Boolean> checkEmailDuplicate(@RequestParam("email") String email);
+
+
+    @Operation(summary = "닉네임 중복 확인", description = "입력한 닉네임이 이미 등록되어 있는지 확인합니다")
+    @ApiResponse(responseCode = "200", description = "닉네임 중복 확인에 성공하였습니다.")
+    @Parameters(value = {
+            @Parameter(name="nickname", description = "닉네임", example = "KSH00610")
+    })
+    @GetMapping("/check-nickname")
+    ResponseEntity<Boolean> checkNicknameDuplicate(@RequestParam("nickname") String nickname);
+
+    @Operation(summary = "프로필 주소 중복 확인", description = "입력한 프로필 주소가 이미 등록되어 있는지 확인합니다")
+    @ApiResponse(responseCode = "200", description = "프로필 주소 중복 확인에 성공하였습니다.")
+    @Parameters(value = {
+            @Parameter(name="profileAddress", description = "프로필 주소", example = "KSH")
+    })
+    @GetMapping("/check-profileAddress")
+    ResponseEntity<Boolean> checkProfileAddressDuplicate(@RequestParam("profileAddress") String profileAddress);
 }

--- a/src/main/java/com/backend_potato/edubox_team2/domain/users/entity/LoginRequestDTO.java
+++ b/src/main/java/com/backend_potato/edubox_team2/domain/users/entity/LoginRequestDTO.java
@@ -1,5 +1,6 @@
 package com.backend_potato.edubox_team2.domain.users.entity;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -7,10 +8,12 @@ import lombok.Data;
 
 @Data
 public class LoginRequestDTO {
+    @Schema(description = "회원 이메일", example = "spancer1@naver.com")
     @NotBlank(message = "이메일은 필수 항목입니다.")
     @Email(message = "유효한 이메일 주소를 입력해야 합니다.")
     private String email;
 
+    @Schema(description = "비밀번호", example = "rlatngus@1")
     @NotBlank(message = "비밀번호는 필수 항목입니다.")
     @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
     private String pw;

--- a/src/main/java/com/backend_potato/edubox_team2/domain/users/entity/SignupRequestDTO.java
+++ b/src/main/java/com/backend_potato/edubox_team2/domain/users/entity/SignupRequestDTO.java
@@ -1,5 +1,6 @@
 package com.backend_potato.edubox_team2.domain.users.entity;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -11,19 +12,19 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor
 public class SignupRequestDTO {
+    @Schema(description = "회원 이메일", example = "spancer1@naver.com")
     @NotBlank(message = "이메일은 필수 항목입니다.")
     @Email(message = "유효한 이메일 주소를 입력해야 합니다.")
     @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$",
             message = "올바른 이메일 형식을 입력해야 합니다.")
     private String email;
 
+    @Schema(description = "비밀번호", example = "rlatngus@1")
     @NotBlank(message = "비밀번호는 필수 항목입니다.")
     @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
     private String pw;
 
+    @Schema(description = "비밀번호", example = "rlatngus@1")
     @NotBlank(message = "비밀번호 확인은 필수 항목입니다.")
     private String confirmPw;
-
-    @NotBlank(message = "인증 코드는 필수 항목입니다.")
-    private String verificationCode;
 }

--- a/src/main/java/com/backend_potato/edubox_team2/domain/users/entity/User.java
+++ b/src/main/java/com/backend_potato/edubox_team2/domain/users/entity/User.java
@@ -51,6 +51,9 @@ public class User {
     @Column(name = "create_at", nullable = false, updatable = false)
     private LocalDateTime createAt;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @ColumnDefault("false")
     private boolean isDelete;
 }

--- a/src/main/java/com/backend_potato/edubox_team2/domain/users/repository/UserRepository.java
+++ b/src/main/java/com/backend_potato/edubox_team2/domain/users/repository/UserRepository.java
@@ -16,13 +16,13 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository <User, Long>{
 
     Boolean existsByEmail(String email);
-
     Boolean existsByNickname(String nickname);
+    Boolean existsByProfileAddress(String profileAddress);
+
+    @Query("SELECT u FROM User u WHERE u.email = :email AND u.isDelete = false")
+    Optional<User> findActiveUserByEmail(@Param("email") String email);
 
     Optional<User> findByEmail(String email);
-
-    Optional<User> findByEmailAndPw(String email, String pw);
-
     @Query("SELECT u.pw FROM User u WHERE u.email = :email")
     String findPasswordByEmail(@Param("email") String email);
 
@@ -30,8 +30,16 @@ public interface UserRepository extends JpaRepository <User, Long>{
     @Query("UPDATE User u SET u.pw = :newPassword WHERE u.email = :email")
     void updatePassword(@Param("email") String email, @Param("newPassword") String newPassword);
 
-    @Query("SELECT u FROM User u WHERE u.isDelete = true AND u.createAt <= :cutoffDate")
-    List<User> findAllByIsDeleteTrueAndCreateAtBefore(@Param("cutoffDate") LocalDateTime cutoffDate);
 
-    //    void deleteAll(List<User> users);
+    @Query("SELECT u FROM User u WHERE u.isDelete = true AND u.deletedAt <= :cutoffDate")
+    List<User> findAllByIsDeleteTrueAndDeletedAtBefore(@Param("cutoffDate") LocalDateTime cutoffDate);
+
+//    void deleteAll(List<User> users);
+
+//    Optional<User> findByEmailAndPw(String email, String pw);
+
+
+//    @Query("SELECT u FROM User u WHERE u.isDelete = true AND u.createAt <= :cutoffDate")
+//    List<User> findAllByIsDeleteTrueAndCreateAtBefore(@Param("cutoffDate") LocalDateTime cutoffDate);
+
 }

--- a/src/main/java/com/backend_potato/edubox_team2/domain/users/scheduler/UserCleanupScheduler.java
+++ b/src/main/java/com/backend_potato/edubox_team2/domain/users/scheduler/UserCleanupScheduler.java
@@ -1,0 +1,18 @@
+package com.backend_potato.edubox_team2.domain.users.scheduler;
+
+import com.backend_potato.edubox_team2.domain.users.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserCleanupScheduler {
+
+    private final UserService userService;
+
+    @Scheduled(cron = "0 0 3 * * ?") // 매일 새벽 3시에 실행
+    public void performHardDelete() {
+        userService.hardDeleteUsers();
+    }
+}

--- a/src/main/java/com/backend_potato/edubox_team2/domain/users/service/EmailService.java
+++ b/src/main/java/com/backend_potato/edubox_team2/domain/users/service/EmailService.java
@@ -4,6 +4,7 @@ import jakarta.mail.MessagingException;
 import org.springframework.mail.SimpleMailMessage;
 
 public interface EmailService {
-    void sendVerificationCode(String email);
-    boolean verifyCode(String email, String code);
+    void sendVerificationLink(String email);
+//    void sendVerificationCode(String email);
+//    boolean verifyCode(String email, String code);
 }

--- a/src/main/java/com/backend_potato/edubox_team2/domain/users/service/EmailServiceImpl.java
+++ b/src/main/java/com/backend_potato/edubox_team2/domain/users/service/EmailServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
@@ -31,21 +32,83 @@ public class EmailServiceImpl implements  EmailService{
     }
 
     @Override
-    public void sendVerificationCode(String email) {
-        String verificationCode = String.valueOf((int) ((Math.random() * 900000) + 100000)); // Generate 6-digit code
-        redisTemplate.opsForValue().set(email, verificationCode, 5, TimeUnit.MINUTES); // Save to Redis for 5 minutes
+    public void sendVerificationLink(String email) {
+        String verificationToken = UUID.randomUUID().toString();
+        redisTemplate.opsForValue().set(verificationToken, email, 24, TimeUnit.HOURS);
 
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(email);
-        message.setSubject("Email Verification Code");
-        message.setText("Your verification code is: " + verificationCode);
-        mailSender.send(message);
-    }
+        String link = "http://localhost:8080/api/user/verify-link?token=" + verificationToken;
 
-    @Override
-    public boolean verifyCode(String email, String code) {
-        String storedCode = redisTemplate.opsForValue().get(email);
-        return storedCode != null && storedCode.equals(code);
+        String htmlContent = """
+            <!DOCTYPE html>
+            <html lang="ko">
+            <head>
+                <meta charset="UTF-8">
+                <title>Email Verification</title>
+            </head>
+            <body style="margin: 0; padding: 0; background-color: #f4f4f4; font-family: Arial, sans-serif; color: #333333;">
+                <table align="center" width="600" cellpadding="0" cellspacing="0" border="0" style="margin: 50px auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1); text-align: center; font-size: 16px;">
+                    <!-- Header -->
+                    <tr>
+                        <td style="background-color: #3cb371; color: #ffffff; padding: 20px; font-size: 24px; font-weight: bold;">
+                            이메일 인증 링크
+                        </td>
+                    </tr>
+                    <!-- Content -->
+                    <tr>
+                        <td style="padding: 30px 20px;">
+                            <h1 style="font-size: 22px; color: #333333; margin-bottom: 15px;">이메일 인증을 완료해주세요</h1>
+                            <p style="font-size: 16px; color: #555555; margin-bottom: 20px;">
+                                이메일 인증을 위해 아래 버튼을 클릭해주세요.
+                            </p>
+                            <a href="%s" style="display: inline-block; padding: 12px 25px; font-size: 16px; color: #ffffff; background-color: #3cb371; text-decoration: none; border-radius: 5px; font-weight: bold;">
+                                이메일 인증하기
+                            </a>
+                        </td>
+                    </tr>
+                    <!-- Footer -->
+                    <tr>
+                        <td style="background-color: #f9f9f9; padding: 15px; font-size: 12px; color: #777777;">
+                            <p style="margin: 0;">© 2024 Your Company. All rights reserved.</p>
+                            <p style="margin: 5px 0;">
+                                이 메일은 자동으로 발송되었습니다. 문의사항이 있을 경우 
+                                <a href="mailto:support@yourcompany.com" style="color: #3cb371; text-decoration: none;">support@yourcompany.com</a>으로 연락해주세요.
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </body>
+            </html>
+            """.formatted(link);
+
+
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            helper.setTo(email);
+            helper.setSubject("Email Verification Link");
+            helper.setText(htmlContent, true);
+
+            mailSender.send(message);
+        } catch (MessagingException e) {
+            throw new IllegalStateException("Failed to send email", e);
+        }
     }
+//    @Override
+//    public void sendVerificationCode(String email) {
+//        String verificationCode = String.valueOf((int) ((Math.random() * 900000) + 100000)); // Generate 6-digit code
+//        redisTemplate.opsForValue().set(email, verificationCode, 5, TimeUnit.MINUTES); // Save to Redis for 5 minutes
+//
+//        SimpleMailMessage message = new SimpleMailMessage();
+//        message.setTo(email);
+//        message.setSubject("Email Verification Code");
+//        message.setText("Your verification code is: " + verificationCode);
+//        mailSender.send(message);
+//    }
+//
+//    @Override
+//    public boolean verifyCode(String email, String code) {
+//        String storedCode = redisTemplate.opsForValue().get(email);
+//        return storedCode != null && storedCode.equals(code);
+//    }
 
 }

--- a/src/main/java/com/backend_potato/edubox_team2/domain/users/service/UserService.java
+++ b/src/main/java/com/backend_potato/edubox_team2/domain/users/service/UserService.java
@@ -11,16 +11,18 @@ import org.springframework.web.multipart.MultipartFile;
 public interface UserService {
 
     void createUser(SignupRequestDTO signupRequestDTO);
-
-    String getUserByEmailAndPw(LoginRequestDTO loginRequestDTO);
-
     void updateProfile(MultipartFile image, ProfileUpdateRequestDTO profileUpdateRequestDTO, HttpServletRequest request);
-    void storeAccessToken(String email, String accessToken);
-    boolean isValidAccessToken(String accessToken);
+
     User authenticate(LoginRequestDTO loginRequestDTO);
 
     void removeAccessToken(String accessToken);
-
-    String saveProfileImage(MultipartFile profile);
-
+    String verifyEmailLink(String token);
+    void softDeleteUserByEmail(String email);
+    void hardDeleteUsers();
+    void restoreUser(String email);
+    boolean existsByEmail(String email);
+    boolean existsByNickname(String nickname);
+    boolean existsByProfileAddress(String profileAddress);
+    void storeAccessToken(String email, String accessToken);
+    boolean isValidAccessToken(String accessToken);
 }

--- a/src/main/java/com/backend_potato/edubox_team2/global/config/SecurityConfig.java
+++ b/src/main/java/com/backend_potato/edubox_team2/global/config/SecurityConfig.java
@@ -47,7 +47,8 @@ public class SecurityConfig {
                                 "/api/user/login",
                                 "/api/user/signup",
                                 "/api/user/verify-code",
-                                "/api/user/send-verification"
+                                "/api/user/send-verification",
+                                "/api/user/verify-link"
                         ).permitAll()
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated()

--- a/src/main/java/com/backend_potato/edubox_team2/global/jwt/JwtFilter.java
+++ b/src/main/java/com/backend_potato/edubox_team2/global/jwt/JwtFilter.java
@@ -31,7 +31,7 @@ public class JwtFilter extends OncePerRequestFilter {
         if (requestURI.startsWith("/swagger-ui") || requestURI.startsWith("/v3/api-docs") ||
                 requestURI.startsWith("/swagger-resources") || requestURI.startsWith("/api/user/login") ||
                 requestURI.startsWith("/api/user/signup") || requestURI.startsWith("/api/user/verify-code")
-                || requestURI.startsWith("/api/user/send-verification")) {
+                || requestURI.startsWith("/api/user/send-verification") || requestURI.startsWith("/api/user/verify-link")) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/test/java/com/backend_potato/edubox_team2/domain/users/controller/UserRestControllerTest.java
+++ b/src/test/java/com/backend_potato/edubox_team2/domain/users/controller/UserRestControllerTest.java
@@ -1,0 +1,100 @@
+package com.backend_potato.edubox_team2.domain.users.controller;
+
+import com.backend_potato.edubox_team2.domain.users.entity.SignupRequestDTO;
+import com.backend_potato.edubox_team2.domain.users.service.EmailService;
+import com.backend_potato.edubox_team2.domain.users.service.UserService;
+import com.backend_potato.edubox_team2.global.jwt.JwtFilter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import com.backend_potato.edubox_team2.global.jwt.JwtTokenUtil;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+@SpringBootTest
+public class UserRestControllerTest {
+
+    private MockMvc mockMvc;
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private EmailService emailService;
+    @Mock
+    private JwtFilter jwtFilter;
+    @Mock
+    private JwtTokenUtil jwtTokenUtil;
+    @InjectMocks
+    private UserRestController userRestController;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(userRestController).build();
+        objectMapper = new ObjectMapper();
+    }
+    @Test
+    void testUserSignup() throws Exception {
+        // Mock input
+        SignupRequestDTO signupRequestDTO = SignupRequestDTO.builder()
+                .email("spancer1@naver.com")
+                .pw("rlatngus@1")
+                .confirmPw("rlatngus@1")
+                .build();
+
+        // Mock the service method
+        Mockito.doNothing().when(userService).createUser(any(SignupRequestDTO.class));
+
+        // Perform the request
+        mockMvc.perform(post("/api/user/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(signupRequestDTO)))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void testVerifyLink() throws Exception {
+        // Mock input
+        String token = "mockToken";
+        String expectedMessage = "Email successfully verified. You can now log in.";
+
+        // Mock the service behavior
+        Mockito.when(userService.verifyEmailLink(token)).thenReturn(expectedMessage);
+
+        // Perform the request
+        mockMvc.perform(get("/api/user/verify-link")
+                        .param("token", token))
+                .andExpect(status().isOk())
+                .andExpect(content().string(expectedMessage));
+    }
+
+    @Test
+    void testLogout() throws Exception {
+        // Mock the service behavior
+        String mockAccessToken = "mockAccessToken";
+        Mockito.when(jwtFilter.resolveToken(any(HttpServletRequest.class))).thenReturn(mockAccessToken);
+        Mockito.when(jwtTokenUtil.isValidToken(mockAccessToken)).thenReturn(true);
+
+        // Mock service behavior
+        Mockito.doNothing().when(userService).removeAccessToken(mockAccessToken);
+
+        // Perform the logout request
+        mockMvc.perform(post("/api/user/logout"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Logged out successfully"));
+    }
+
+}


### PR DESCRIPTION
refactor: 이메일 인증 방식을 인증 코드에서 인증 링크로 변경
- 기존 이메일 인증 시 인증 코드를 사용한 방식에서 이메일 인증 링크 방식으로 변경
- 이메일 인증 코드에서 사용된 VerifyCodeRequestDTO, EmailVerificationRequestDTO 추후 사용 가능 여부로 인해 domain/deprecated 폴더로 이동
- 기존 이메일로 전송되는 html 코드에 css 적용해 스타일 수정